### PR TITLE
Use nhs data aws

### DIFF
--- a/homebrewAWSLambdaServer/src/main/java/org/scottishtecharmy/homebrewdemo/LambdaFunctionHandler.java
+++ b/homebrewAWSLambdaServer/src/main/java/org/scottishtecharmy/homebrewdemo/LambdaFunctionHandler.java
@@ -129,11 +129,11 @@ public class LambdaFunctionHandler implements RequestHandler<S3Event, String> {
         try (CloseableHttpResponse response = client.execute(request)) {
             int statusCode = response.getStatusLine().getStatusCode();
             if (HttpStatus.SC_NOT_MODIFIED == statusCode) {
-                context.getLogger().log("NHS health boards data not updated - skipping\n");
+                context.getLogger().log("NHS data not updated - skipping\n");
                 return;
             }
             if (HttpStatus.SC_OK != statusCode) {
-                context.getLogger().log("NHS health boards data error response: " + statusCode + "\n");
+                context.getLogger().log("NHS data error response: " + statusCode + "\n");
                 return;
             }
 

--- a/homebrewAWSLambdaServer/src/main/java/org/scottishtecharmy/homebrewdemo/LambdaFunctionHandler.java
+++ b/homebrewAWSLambdaServer/src/main/java/org/scottishtecharmy/homebrewdemo/LambdaFunctionHandler.java
@@ -13,7 +13,9 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.stream.Collectors;
 
+import org.apache.http.Header;
 import org.apache.http.HttpEntity;
+import org.apache.http.HttpStatus;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -57,36 +59,10 @@ public class LambdaFunctionHandler implements RequestHandler<S3Event, String> {
 
         try {
             context.getLogger().log("start");
-            String storedDates = getObject(OBJECTKEY_DATES_MODIFIED);
-            String newDates = getStatsQuery(QUERY_DATES_MODIFIED, context);
-
-            if (isDateModified(storedDates, newDates)) {
-
-                storeStatsQuery(QUERY_WEEKLY_HEALTH_BOARDS_DEATHS, OBJECTKEY_WEEKLY_HEALTH_BOARDS_DEATHS, context);
-                storeStatsQuery(QUERY_DAILY_SCOTTISH_CASES_AND_DEATHS, OBJECTKEY_DAILY_SCOTTISH_CASES_AND_DEATHS,
-                        context);
-                storeStatsQuery(QUERY_WEEKLY_COUNCIL_AREAS_DEATHS, OBJECTKEY_WEEKLY_COUNCIL_AREAS_DEATHS, context);
-                storeStatsQuery(QUERY_DAILY_HEALTH_BOARDS_CASES, OBJECTKEY_DAILY_HEALTH_BOARDS_CASES, context);
-                storeStatsQuery(QUERY_DAILY_HEALTH_BOARDS_CASES_AND_PATIENTS,
-                        OBJECTKEY_DAILY_HEALTH_BOARDS_CASES_AND_PATIENTS, context);
-
-                String last7Days = getDaysDateValueClause();
-                String last2Years = getYearsDateValueClause();
-
-                storeStatsQuery(QUERYTEMPLATE_SUMMARY_COUNTS.replace(LAST_7_DAYS, last7Days), OBJECTKEY_SUMMARY_COUNTS,
-                        context);
-                storeStatsQuery(QUERYTEMPLATE_ANNUAL_HEALTH_BOARDS_DEATHS.replace(LAST_2_YEARS, last2Years),
-                        OBJECTKEY_ANNUAL_HEALTH_BOARDS_DEATHS, context);
-                storeStatsQuery(QUERYTEMPLATE_ANNUAL_COUNCIL_AREAS_DEATHS.replace(LAST_2_YEARS, last2Years),
-                        OBJECTKEY_ANNUAL_COUNCIL_AREAS_DEATHS, context);
-
-                // Got everything else - store datesModified
-                storeObject(context, newDates, OBJECTKEY_DATES_MODIFIED);
-                context.getLogger().log("datesModified updated\n");
-            } else {
-                context.getLogger().log("datesModified not updated - skipping stats queries\n");
-            }
+            storeStatsGovData(context);
             
+            storeAllNhsScotData(context);
+
             storeRssNewsFeed(context);
 
             context.getLogger().log("end");
@@ -98,6 +74,99 @@ public class LambdaFunctionHandler implements RequestHandler<S3Event, String> {
         }
 
         return "Success";
+    }
+
+    private void storeStatsGovData(Context context) throws IOException, ClientProtocolException {
+        String storedDates = getObject(context, OBJECTKEY_STATS_GOV_DATES_MODIFIED);
+        String newDates = getStatsQuery(QUERY_STATS_GOV_DATES_MODIFIED, context);
+
+        if (isDateModified(storedDates, newDates)) {
+
+            storeStatsQuery(QUERY_WEEKLY_HEALTH_BOARDS_DEATHS, OBJECTKEY_WEEKLY_HEALTH_BOARDS_DEATHS, context);
+            storeStatsQuery(QUERY_DAILY_SCOTTISH_CASES_AND_DEATHS, OBJECTKEY_DAILY_SCOTTISH_CASES_AND_DEATHS, context);
+            storeStatsQuery(QUERY_WEEKLY_COUNCIL_AREAS_DEATHS, OBJECTKEY_WEEKLY_COUNCIL_AREAS_DEATHS, context);
+            storeStatsQuery(QUERY_DAILY_HEALTH_BOARDS_CASES, OBJECTKEY_DAILY_HEALTH_BOARDS_CASES, context);
+            storeStatsQuery(QUERY_DAILY_HEALTH_BOARDS_CASES_AND_PATIENTS,
+                    OBJECTKEY_DAILY_HEALTH_BOARDS_CASES_AND_PATIENTS, context);
+
+            String last7Days = getDaysDateValueClause();
+            String last2Years = getYearsDateValueClause();
+
+            storeStatsQuery(QUERYTEMPLATE_SUMMARY_COUNTS.replace(LAST_7_DAYS, last7Days), OBJECTKEY_SUMMARY_COUNTS,
+                    context);
+            storeStatsQuery(QUERYTEMPLATE_ANNUAL_HEALTH_BOARDS_DEATHS.replace(LAST_2_YEARS, last2Years),
+                    OBJECTKEY_ANNUAL_HEALTH_BOARDS_DEATHS, context);
+            storeStatsQuery(QUERYTEMPLATE_ANNUAL_COUNCIL_AREAS_DEATHS.replace(LAST_2_YEARS, last2Years),
+                    OBJECTKEY_ANNUAL_COUNCIL_AREAS_DEATHS, context);
+
+            // Got everything else - store datesModified
+            storeObject(context, newDates, OBJECTKEY_STATS_GOV_DATES_MODIFIED);
+            context.getLogger().log("datesModified updated\n");
+        }
+        else {
+            context.getLogger().log("datesModified not updated - skipping stats queries\n");
+        }
+    }
+
+    private void storeAllNhsScotData(Context context) throws IOException, ClientProtocolException {
+        storeNhsScotData(context, OBJECTKEY_NHS_SCOT_DAILY_COUNCIL_AREAS,
+                OBJECTKEY_NHS_SCOT_DAILY_COUNCIL_AREAS_LAST_MODIFIED, NHS_SCOT_DAILY_COUNCIL_AREAS_URL);
+        storeNhsScotData(context, OBJECTKEY_NHS_SCOT_DAILY_HEALTH_BOARDS,
+                OBJECTKEY_NHS_SCOT_DAILY_HEALTH_BOARDS_LAST_MODIFIED, NHS_SCOT_DAILY_HEALTH_BOARDS_URL);
+    }
+
+    private void storeNhsScotData(Context context, String objectKeyData, String objectKeyModificationDate,
+            String retrievalUrl) throws IOException, ClientProtocolException {
+        String modificationDate = getObject(context, objectKeyModificationDate);
+
+        context.getLogger().log("Call request\n");
+        HttpGet request = new HttpGet(retrievalUrl);
+        if (modificationDate != null) {
+            request.addHeader("If-Modified-Since", modificationDate);
+        }
+
+        CloseableHttpClient client = createHttpClient();
+        try (CloseableHttpResponse response = client.execute(request)) {
+            int statusCode = response.getStatusLine().getStatusCode();
+            if (HttpStatus.SC_NOT_MODIFIED == statusCode) {
+                context.getLogger().log("NHS health boards data not updated - skipping\n");
+                return;
+            }
+            if (HttpStatus.SC_OK != statusCode) {
+                context.getLogger().log("NHS health boards data error response: " + statusCode + "\n");
+                return;
+            }
+
+            context.getLogger().log("Response received\n");
+            Header lastModifiedHeader = response.getFirstHeader("Last-Modified");
+            String newModificationDate = null;
+            if (lastModifiedHeader != null) {
+                newModificationDate = lastModifiedHeader.getValue();
+            }
+
+            // Pipe straight to S3
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setContentType("text/plain");
+
+            HttpEntity entity = response.getEntity();
+            if (entity.getContentLength() > 0) {
+                metadata.setContentLength(entity.getContentLength());
+            }
+
+            AccessControlList acl = new AccessControlList();
+            acl.grantPermission(GroupGrantee.AllUsers, Permission.Read);
+
+            s3.putObject(new PutObjectRequest(BUCKET_NAME, objectKeyData, entity.getContent(), metadata)
+                    .withAccessControlList(acl));
+
+            context.getLogger().log("Response stored in S3 at " + objectKeyData + "\n");
+
+            if (newModificationDate != null) {
+                storeObject(context, newModificationDate, objectKeyModificationDate);
+                context.getLogger().log("Last updated stored in S3 at " + objectKeyModificationDate + "\n");
+            }
+        }
+
     }
 
     // Replaced in unit tests
@@ -189,13 +258,15 @@ public class LambdaFunctionHandler implements RequestHandler<S3Event, String> {
         context.getLogger().log("Object stored in S3 at " + objectKeyName + "\n");
     }
 
-    private String getObject(String objectKeyName)
+    private String getObject(Context context, String objectKeyName)
             throws UnsupportedOperationException, AmazonServiceException, SdkClientException, IOException {
         if (!s3.doesObjectExist(BUCKET_NAME, objectKeyName)) {
+            context.getLogger().log("Object not found in S3 at " + objectKeyName + "\n");
             return null;
         }
-        
+
         try (S3Object storedDatesModified = s3.getObject(BUCKET_NAME, objectKeyName)) {
+            context.getLogger().log("Object retrieved from in S3 at " + objectKeyName + "\n");
             InputStream contentStream = storedDatesModified.getObjectContent();
             return new BufferedReader(new InputStreamReader(contentStream, StandardCharsets.UTF_8)).lines()
                     .collect(Collectors.joining("\n"));
@@ -236,11 +307,24 @@ public class LambdaFunctionHandler implements RequestHandler<S3Event, String> {
                 || !newModificationData.equals(oldModificationData);
     }
 
+    private static final String OBJECT_FOLDER = "data/";
+
+    private final static String NHS_SCOT_DAILY_HEALTH_BOARDS_URL = "https://www.opendata.nhs.scot/dataset/b318bddf-a4dc-4262-971f-0ba329e09b87/resource/2dd8534b-0a6f-4744-9253-9565d62f96c2/download";
+
+    private final static String NHS_SCOT_DAILY_COUNCIL_AREAS_URL = "https://www.opendata.nhs.scot/dataset/b318bddf-a4dc-4262-971f-0ba329e09b87/resource/427f9a25-db22-4014-a3bc-893b68243055/download";
+
+    private final static String OBJECTKEY_NHS_SCOT_DAILY_HEALTH_BOARDS_LAST_MODIFIED = OBJECT_FOLDER
+            + "nhsDailyHealthBoardLastModified.txt";
+    private final static String OBJECTKEY_NHS_SCOT_DAILY_COUNCIL_AREAS_LAST_MODIFIED = OBJECT_FOLDER
+            + "nhsDailyCouncilAreaLastModified.txt";
+
+    private final static String OBJECTKEY_NHS_SCOT_DAILY_HEALTH_BOARDS = OBJECT_FOLDER + "dailyHealthBoards.csv";
+    private final static String OBJECTKEY_NHS_SCOT_DAILY_COUNCIL_AREAS = OBJECT_FOLDER + "dailyCouncilAreas.csv";
+
     private static final String SPARQL_URL = "https://statistics.gov.scot/sparql.csv";
     private static final String BUCKET_NAME = "dashboard.aws.scottishtecharmy.org";
 
-    private static final String OBJECT_FOLDER = "data/";
-    private static final String OBJECTKEY_DATES_MODIFIED = OBJECT_FOLDER + "datesmodified.csv";
+    private static final String OBJECTKEY_STATS_GOV_DATES_MODIFIED = OBJECT_FOLDER + "datesmodified.csv";
     private static final String OBJECTKEY_SUMMARY_COUNTS = OBJECT_FOLDER + "summaryCounts.csv";
     private static final String OBJECTKEY_WEEKLY_HEALTH_BOARDS_DEATHS = OBJECT_FOLDER + "weeklyHealthBoardsDeaths.csv";
     private static final String OBJECTKEY_ANNUAL_HEALTH_BOARDS_DEATHS = OBJECT_FOLDER + "annualHealthBoardsDeaths.csv";
@@ -268,7 +352,6 @@ public class LambdaFunctionHandler implements RequestHandler<S3Event, String> {
             + "?obs <http://statistics.gov.scot/def/dimension/causeOfDeath> <http://statistics.gov.scot/def/concept/cause-of-death/covid-19-related>.\n"
             + "?obs <http://statistics.gov.scot/def/dimension/locationOfDeath> <http://statistics.gov.scot/def/concept/location-of-death/all>.\n";
 
-    
     private static final String QUERYTEMPLATE_SUMMARY_COUNTS = FRAGMENT_COMMON_PREFIXES
             + "SELECT ?date ?shortValue ?count WHERE {\n" + "  VALUES (?value ?shortValue) {\n"
             + "    ( <http://statistics.gov.scot/def/concept/variable/testing-daily-people-found-positive> \"dailyPositiveTests\" )\n"
@@ -349,7 +432,7 @@ public class LambdaFunctionHandler implements RequestHandler<S3Event, String> {
             + "  ?areauri rdfs:label ?areaname.\n" + "  ?obs dim:refPeriod ?perioduri .\n"
             + "  ?perioduri rdfs:label ?date\n" + "}";
 
-    private static final String QUERY_DATES_MODIFIED = "SELECT ?datagraph ?dateModified\n" + "WHERE {\n"
+    private static final String QUERY_STATS_GOV_DATES_MODIFIED = "SELECT ?datagraph ?dateModified\n" + "WHERE {\n"
             + "VALUES (?datagraph) {\n"
             + "( <http://statistics.gov.scot/graph/deaths-involving-coronavirus-covid-19> )\n"
             + "( <http://statistics.gov.scot/graph/coronavirus-covid-19-management-information> )\n" + "}\n"

--- a/homebrewAWSLambdaServer/src/test/java/org/scottishtecharmy/homebrewdemo/LambdaFunctionHandlerTest.java
+++ b/homebrewAWSLambdaServer/src/test/java/org/scottishtecharmy/homebrewdemo/LambdaFunctionHandlerTest.java
@@ -1,6 +1,5 @@
 package org.scottishtecharmy.homebrewdemo;
 
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -12,23 +11,29 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.message.BasicHeader;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.OngoingStubbing;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.S3Event;
@@ -58,8 +63,6 @@ public class LambdaFunctionHandlerTest {
     private S3Object getObjectResult;
     @Mock
     private CloseableHttpClient httpClient;
-    @Mock
-    private CloseableHttpResponse httpResponse;
 
     private LambdaFunctionHandler subject;
 
@@ -70,57 +73,133 @@ public class LambdaFunctionHandlerTest {
     ArgumentCaptor<PutObjectRequest> s3WriteCaptor = ArgumentCaptor.forClass(PutObjectRequest.class);
     ArgumentCaptor<GetObjectRequest> s3ReadCaptor = ArgumentCaptor.forClass(GetObjectRequest.class);
 
-    private static final String[] EXPECTED_S3_PUT_KEYS = { "data/weeklyHealthBoardsDeaths.csv",
-            "data/dailyScottishCasesAndDeaths.csv", "data/weeklyCouncilAreasDeaths.csv",
-            "data/dailyHealthBoardsCases.csv", "data/analysis/dailyHealthBoardsCasesAndPatients.csv",
-            "data/summaryCounts.csv", "data/annualHealthBoardsDeaths.csv", "data/annualCouncilAreasDeaths.csv",
-            "data/datesmodified.csv", "data/newsScotGovRss.xml" };
-
     private static final String DATES_MODIFIED_CONTENT = "datesmodified.output";
+    private static final String LAST_MODIFIED_DATE_HB = "Mon, 10 Aug 2020 12:00:28 GMT";
+    private static final String LAST_MODIFIED_DATE_CA = "Mon, 10 Aug 2020 13:00:28 GMT";
 
-    private static final String[] EXPECTED_S3_PUT_OBJECTS = { "dailyScottishCasesAndDeaths.output",
-            "weeklyCouncilAreasDeaths.output", "dailyHealthBoardsCases.output",
-            "dailyHealthBoardsCasesAndPatients.output", "summaryCounts.output", "annualHealthBoardsDeaths.output",
-            "annualCouncilAreasDeaths.output", "datesmodified.output", DATES_MODIFIED_CONTENT,
-            "newsScotGovRss.output" };
+    // Flatten an array of arrays into a single array - unfortunately generics
+    // don't work here
+    private static String[][] flatten(String[][]... arrays) {
+        return Arrays.stream(arrays).flatMap(o -> Arrays.stream(o)).toArray(String[][]::new);
+    }
 
+    private static CloseableHttpResponse[] flatten(CloseableHttpResponse[]... arrays) {
+        return Arrays.stream(arrays).flatMap(o -> Arrays.stream(o)).toArray(CloseableHttpResponse[]::new);
+    }
+
+    private static final String[][] EXPECTED_S3_PUT_OBJECTS_SPARQL_DATA = {
+            { "data/weeklyHealthBoardsDeaths.csv", "weeklyHealthBoardsDeaths.output" },
+            { "data/dailyScottishCasesAndDeaths.csv", "dailyScottishCasesAndDeaths.output" },
+            { "data/weeklyCouncilAreasDeaths.csv", "weeklyCouncilAreasDeaths.output" },
+            { "data/dailyHealthBoardsCases.csv", "dailyHealthBoardsCases.output", },
+            { "data/analysis/dailyHealthBoardsCasesAndPatients.csv", "dailyHealthBoardsCasesAndPatients.output" },
+            { "data/summaryCounts.csv", "summaryCounts.output" },
+            { "data/annualHealthBoardsDeaths.csv", "annualHealthBoardsDeaths.output" },
+            { "data/annualCouncilAreasDeaths.csv", "annualCouncilAreasDeaths.output" },
+            { "data/datesmodified.csv", DATES_MODIFIED_CONTENT } };
+
+    private static final String[][] EXPECTED_S3_PUT_OBJECTS_NHS_CA_DATA = {
+            { "data/dailyCouncilAreas.csv", "dailyCouncilAreas.output", },
+            { "data/nhsDailyCouncilAreaLastModified.txt", LAST_MODIFIED_DATE_CA }, };
+
+    private static final String[][] EXPECTED_S3_PUT_OBJECTS_NHS_HB_DATA = {
+            { "data/dailyHealthBoards.csv", "dailyHealthBoards.output" },
+            { "data/nhsDailyHealthBoardLastModified.txt", LAST_MODIFIED_DATE_HB }, };
+
+    private static final String[][] EXPECTED_S3_PUT_OBJECTS_NHS_DATA = flatten(EXPECTED_S3_PUT_OBJECTS_NHS_CA_DATA,
+            EXPECTED_S3_PUT_OBJECTS_NHS_HB_DATA);
+
+    private static final String[][] EXPECTED_S3_PUT_OBJECTS_RSS_DATA = {
+            { "data/newsScotGovRss.xml", "newsScotGovRss.output" }, };
+
+    private static final String[][] EXPECTED_S3_PUT_OBJECTS_ALL = flatten(EXPECTED_S3_PUT_OBJECTS_SPARQL_DATA,
+            EXPECTED_S3_PUT_OBJECTS_NHS_DATA, EXPECTED_S3_PUT_OBJECTS_RSS_DATA);
+
+    private static CloseableHttpResponse createHttpResponse(String content, int statusCode, String lastModifiedDate) {
+        CloseableHttpResponse response = Mockito.mock(CloseableHttpResponse.class);
+        StatusLine statusLine = Mockito.mock(StatusLine.class);
+
+        try {
+            when(response.getEntity()).thenReturn(new StringEntity(content));
+            when(response.getStatusLine()).thenReturn(statusLine);
+            when(statusLine.getStatusCode()).thenReturn(statusCode);
+            if (lastModifiedDate != null) {
+                when(response.getFirstHeader("Last-Modified"))
+                        .thenReturn(new BasicHeader("Last-Modified", lastModifiedDate));
+            }
+        }
+        catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+        return response;
+    }
+
+    private static CloseableHttpResponse createHttpResponse(String content) {
+        return createHttpResponse(content, 200, null);
+    }
+
+    // statistics.scot.gov responses
     // Note difference in ordering
-    private static final String[] HTTP_QUERY_RESPONSES = { DATES_MODIFIED_CONTENT, "dailyScottishCasesAndDeaths.output",
-            "weeklyCouncilAreasDeaths.output", "dailyHealthBoardsCases.output",
-            "dailyHealthBoardsCasesAndPatients.output", "summaryCounts.output", "annualHealthBoardsDeaths.output",
-            "annualCouncilAreasDeaths.output", "datesmodified.output", "newsScotGovRss.output", "UNEXPECTED" };
+    private static final CloseableHttpResponse[] HTTP_QUERY_RESPONSES_SPARQL = {
+            createHttpResponse(DATES_MODIFIED_CONTENT), createHttpResponse("weeklyHealthBoardsDeaths.output"),
+            createHttpResponse("dailyScottishCasesAndDeaths.output"),
+            createHttpResponse("weeklyCouncilAreasDeaths.output"), createHttpResponse("dailyHealthBoardsCases.output"),
+            createHttpResponse("dailyHealthBoardsCasesAndPatients.output"), createHttpResponse("summaryCounts.output"),
+            createHttpResponse("annualHealthBoardsDeaths.output"),
+            createHttpResponse("annualCouncilAreasDeaths.output"), };
+
+    // nhs.scot responses
+    private static final CloseableHttpResponse[] HTTP_QUERY_RESPONSES_NHS = {
+            createHttpResponse("dailyCouncilAreas.output", 200, LAST_MODIFIED_DATE_CA),
+            createHttpResponse("dailyHealthBoards.output", 200, LAST_MODIFIED_DATE_HB), };
+
+    // rss feed response
+    private static final CloseableHttpResponse[] HTTP_QUERY_RESPONSES_RSS = {
+            createHttpResponse("newsScotGovRss.output"), };
+
+    // Unexpected additional responses
+    private static final CloseableHttpResponse[] HTTP_QUERY_RESPONSES_UNEXPECTED = { createHttpResponse("UNEXPECTED") };
+
+    private static final CloseableHttpResponse[] HTTP_QUERY_RESPONSES = flatten(HTTP_QUERY_RESPONSES_SPARQL,
+            HTTP_QUERY_RESPONSES_NHS, HTTP_QUERY_RESPONSES_RSS, HTTP_QUERY_RESPONSES_UNEXPECTED);
 
     @Before
     public void setUp() throws IOException {
-        context = createContext();
-
+        context = new TestContext();
         event = TestUtils.parse("/s3-event.put.json", S3Event.class);
-
         subject = spy(new LambdaFunctionHandler(s3Client));
 
         // Handle S3 puts
         when(s3Client.putObject(s3WriteCaptor.capture())).thenReturn(putObjectResult);
 
-        // Handle S3 last date modified retrieval
-        when(s3Client.doesObjectExist("dashboard.aws.scottishtecharmy.org", "data/datesmodified.csv")).thenReturn(true);
-        when(s3Client.getObject("dashboard.aws.scottishtecharmy.org", "data/datesmodified.csv"))
-                .thenReturn(retrievedDateModifiedObject);
-        when(retrievedDateModifiedObject.getObjectContent())
-                .thenReturn(new S3ObjectInputStream(new ByteArrayInputStream("datesoriginal.output".getBytes()), null));
+        // Handle S3 gets
+        mockStoredS3Object(retrievedDateModifiedObject, "data/datesmodified.csv", "datesoriginal.output");
+        mockStoredS3Object(Mockito.mock(S3Object.class), "data/nhsDailyHealthBoardLastModified.txt",
+                LAST_MODIFIED_DATE_HB);
+        mockStoredS3Object(Mockito.mock(S3Object.class), "data/nhsDailyCouncilAreaLastModified.txt",
+                LAST_MODIFIED_DATE_CA);
 
         // Handle external HTTP queries
         when(subject.createHttpClient()).thenReturn(httpClient);
-        when(httpClient.execute(httpRequestCaptor.capture())).thenReturn(httpResponse);
-
-        StringEntity[] ongoingResponses = new StringEntity[HTTP_QUERY_RESPONSES.length - 1];
-        for (int i = 1; i < HTTP_QUERY_RESPONSES.length; i++) {
-            ongoingResponses[i - 1] = new StringEntity(HTTP_QUERY_RESPONSES[i]);
-        }
-        when(httpResponse.getEntity()).thenReturn(new StringEntity(HTTP_QUERY_RESPONSES[0]), ongoingResponses);
+        returnMultiple(when(httpClient.execute(httpRequestCaptor.capture())), HTTP_QUERY_RESPONSES);
     }
 
-    private Context createContext() {
-        return new TestContext();
+    private void mockStoredS3Object(S3Object mockS3Object, String objectKey, String content) {
+        when(s3Client.doesObjectExist("dashboard.aws.scottishtecharmy.org", objectKey)).thenReturn(true);
+        when(s3Client.getObject("dashboard.aws.scottishtecharmy.org", objectKey)).thenReturn(mockS3Object);
+        when(mockS3Object.getObjectContent())
+                .thenReturn(new S3ObjectInputStream(new ByteArrayInputStream(content.getBytes()), null));
+    }
+
+    // An helper when wanting to return a sequence of responses stored as an
+    // array
+    @SuppressWarnings("unchecked")
+    private static final <T> OngoingStubbing<T> returnMultiple(OngoingStubbing<T> input, T[] responses) {
+        T first = responses[0];
+        T[] rest = (T[]) new Object[responses.length - 1];
+        System.arraycopy(responses, 1, rest, 0, responses.length - 1);
+
+        return input.thenReturn(first, rest);
     }
 
     @Test
@@ -142,20 +221,18 @@ public class LambdaFunctionHandlerTest {
     public void testLambdaFunctionHandler_dateNotModified() throws UnsupportedOperationException, IOException {
         when(retrievedDateModifiedObject.getObjectContent())
                 .thenReturn(new S3ObjectInputStream(new ByteArrayInputStream(DATES_MODIFIED_CONTENT.getBytes()), null));
-        when(httpResponse.getEntity()).thenReturn(new StringEntity(DATES_MODIFIED_CONTENT),
-                new StringEntity("newsScotGovRss.output"));
 
-        String output = subject.handleRequest(event, context);
-        assertEquals("Success", output);
+        CloseableHttpResponse[] httpResponses = flatten(
+                new CloseableHttpResponse[] { createHttpResponse(DATES_MODIFIED_CONTENT), }, HTTP_QUERY_RESPONSES_NHS,
+                HTTP_QUERY_RESPONSES_RSS, HTTP_QUERY_RESPONSES_UNEXPECTED);
 
-        List<HttpUriRequest> httpRequests = httpRequestCaptor.getAllValues();
-        assertEquals(2, httpRequests.size());
-        // The first is a request to statistics.gov.scot
-        checkSparQLPostRequest((HttpPost) httpRequests.get(0));
-        // The last is a request to news.gov.scot rss feed
-        checkRssFeedGetRequest((HttpGet) httpRequests.get(1));
+        httpRequestCaptor = ArgumentCaptor.forClass(HttpUriRequest.class);
+        returnMultiple(when(httpClient.execute(httpRequestCaptor.capture())), httpResponses);
 
-        checkS3Writes(new String[] { "data/newsScotGovRss.xml" }, new String[] { "newsScotGovRss.output" });
+        assertEquals("Success", subject.handleRequest(event, context));
+
+        checkRequests_sparqlDataRequestsNotMade();
+        checkS3Writes(flatten(EXPECTED_S3_PUT_OBJECTS_NHS_DATA, EXPECTED_S3_PUT_OBJECTS_RSS_DATA));
     }
 
     @Test
@@ -164,17 +241,8 @@ public class LambdaFunctionHandlerTest {
         String output = subject.handleRequest(event, context);
         assertEquals("Success", output);
 
-        int expectedRequestCount = 10;
-        List<HttpUriRequest> httpRequests = httpRequestCaptor.getAllValues();
-        assertEquals(expectedRequestCount, httpRequests.size());
-        // The first n - 1 are requests to statistics.gov.scot
-        for (int i = 0; i < expectedRequestCount - 1; i++) {
-            checkSparQLPostRequest((HttpPost) httpRequests.get(i));
-        }
-        // The last is a request to news.gov.scot rss feed
-        checkRssFeedGetRequest((HttpGet) httpRequests.get(expectedRequestCount - 1));
-
-        checkS3Writes(EXPECTED_S3_PUT_KEYS, EXPECTED_S3_PUT_OBJECTS);
+        checkRequests_allRequestsMade();
+        checkS3Writes(EXPECTED_S3_PUT_OBJECTS_ALL);
     }
 
     @Test
@@ -183,19 +251,128 @@ public class LambdaFunctionHandlerTest {
         when(s3Client.doesObjectExist("dashboard.aws.scottishtecharmy.org", "data/datesmodified.csv"))
                 .thenReturn(false);
 
+        assertEquals("Success", subject.handleRequest(event, context));
+
+        checkRequests_allRequestsMade();
+        checkS3Writes(EXPECTED_S3_PUT_OBJECTS_ALL);
+    }
+
+    @Test
+    public void testLambdaFunctionHandler_storedNhsHealthBoardDateModifiedMissing()
+            throws UnsupportedOperationException, IOException {
+        when(s3Client.doesObjectExist("dashboard.aws.scottishtecharmy.org", "data/nhsDailyHealthBoardLastModified.txt"))
+                .thenReturn(false);
+
+        assertEquals("Success", subject.handleRequest(event, context));
+
+        checkRequests_allRequestsMade();
+        checkS3Writes(EXPECTED_S3_PUT_OBJECTS_ALL);
+
+        List<HttpUriRequest> httpRequests = httpRequestCaptor.getAllValues();
+        checkNhsGetRequestModificationDate((HttpGet) httpRequests.get(9), LAST_MODIFIED_DATE_CA);
+        checkNhsGetRequestModificationDate((HttpGet) httpRequests.get(10), null);
+    }
+
+    @Test
+    public void testLambdaFunctionHandler_storedNhsCouncilAreaDateModifiedMissing()
+            throws UnsupportedOperationException, IOException {
+        when(s3Client.doesObjectExist("dashboard.aws.scottishtecharmy.org", "data/nhsDailyCouncilAreaLastModified.txt"))
+                .thenReturn(false);
+
+        assertEquals("Success", subject.handleRequest(event, context));
+
+        checkRequests_allRequestsMade();
+        checkS3Writes(EXPECTED_S3_PUT_OBJECTS_ALL);
+    }
+
+    @Test
+    public void testLambdaFunctionHandler_storedNhsCouncilAreaNotUpdated()
+            throws UnsupportedOperationException, IOException {
+
+        CloseableHttpResponse[] httpResponses = flatten(HTTP_QUERY_RESPONSES_SPARQL,
+                new CloseableHttpResponse[] {
+                        createHttpResponse("dailyCouncilAreas.output", 304, LAST_MODIFIED_DATE_CA),
+                        createHttpResponse("dailyHealthBoards.output", 200, LAST_MODIFIED_DATE_HB), },
+                HTTP_QUERY_RESPONSES_RSS, HTTP_QUERY_RESPONSES_UNEXPECTED);
+
+        httpRequestCaptor = ArgumentCaptor.forClass(HttpUriRequest.class);
+        returnMultiple(when(httpClient.execute(httpRequestCaptor.capture())), httpResponses);
+
+        assertEquals("Success", subject.handleRequest(event, context));
+
+        checkRequests_allRequestsMade();
+        checkS3Writes(flatten(EXPECTED_S3_PUT_OBJECTS_SPARQL_DATA, EXPECTED_S3_PUT_OBJECTS_NHS_HB_DATA,
+                EXPECTED_S3_PUT_OBJECTS_RSS_DATA));
+    }
+
+    @Test
+    public void testLambdaFunctionHandler_storedNhsHealthBoardNotUpdated()
+            throws UnsupportedOperationException, IOException {
+
+        CloseableHttpResponse[] httpResponses = flatten(HTTP_QUERY_RESPONSES_SPARQL,
+                new CloseableHttpResponse[] {
+                        createHttpResponse("dailyCouncilAreas.output", 200, LAST_MODIFIED_DATE_CA),
+                        createHttpResponse("dailyHealthBoards.output", 304, LAST_MODIFIED_DATE_HB), },
+                HTTP_QUERY_RESPONSES_RSS, HTTP_QUERY_RESPONSES_UNEXPECTED);
+
+        httpRequestCaptor = ArgumentCaptor.forClass(HttpUriRequest.class);
+        returnMultiple(when(httpClient.execute(httpRequestCaptor.capture())), httpResponses);
+
         String output = subject.handleRequest(event, context);
         assertEquals("Success", output);
 
+        checkRequests_allRequestsMade();
+        checkS3Writes(flatten(EXPECTED_S3_PUT_OBJECTS_SPARQL_DATA, EXPECTED_S3_PUT_OBJECTS_NHS_CA_DATA,
+                EXPECTED_S3_PUT_OBJECTS_RSS_DATA));
+    }
+
+    @Test
+    public void testLambdaFunctionHandler_storedNhsDataNotUpdated() throws UnsupportedOperationException, IOException {
+
+        CloseableHttpResponse[] httpResponses = flatten(HTTP_QUERY_RESPONSES_SPARQL,
+                new CloseableHttpResponse[] {
+                        createHttpResponse("dailyCouncilAreas.output", 304, LAST_MODIFIED_DATE_CA),
+                        createHttpResponse("dailyHealthBoards.output", 304, LAST_MODIFIED_DATE_HB), },
+                HTTP_QUERY_RESPONSES_RSS, HTTP_QUERY_RESPONSES_UNEXPECTED);
+
+        httpRequestCaptor = ArgumentCaptor.forClass(HttpUriRequest.class);
+        returnMultiple(when(httpClient.execute(httpRequestCaptor.capture())), httpResponses);
+
+        assertEquals("Success", subject.handleRequest(event, context));
+
+        checkRequests_allRequestsMade();
+        checkS3Writes(flatten(EXPECTED_S3_PUT_OBJECTS_SPARQL_DATA, EXPECTED_S3_PUT_OBJECTS_RSS_DATA));
+    }
+
+    private void checkRequests_sparqlDataRequestsNotMade() throws UnsupportedOperationException, IOException {
         List<HttpUriRequest> httpRequests = httpRequestCaptor.getAllValues();
-        assertEquals(10, httpRequests.size());
+        assertEquals(4, httpRequests.size());
+
+        // The first is a request to statistics.gov.scot
+        checkSparQLPostRequest((HttpPost) httpRequests.get(0));
+
+        // The next 2 are requests to nhs.scot
+        checkNhsGetRequest((HttpGet) httpRequests.get(1));
+        checkNhsGetRequest((HttpGet) httpRequests.get(2));
+
+        // The last is a request to news.gov.scot rss feed
+        checkRssFeedGetRequest((HttpGet) httpRequests.get(3));
+    }
+
+    private void checkRequests_allRequestsMade() throws UnsupportedOperationException, IOException {
+        List<HttpUriRequest> httpRequests = httpRequestCaptor.getAllValues();
+        assertEquals(12, httpRequests.size());
         // The first 9 are requests to statistics.gov.scot
         for (int i = 0; i < 9; i++) {
             checkSparQLPostRequest((HttpPost) httpRequests.get(i));
         }
-        // The last is a request to news.gov.scot rss feed
-        checkRssFeedGetRequest((HttpGet) httpRequests.get(9));
 
-        checkS3Writes(EXPECTED_S3_PUT_KEYS, EXPECTED_S3_PUT_OBJECTS);
+        // The next 2 are requests to nhs.scot
+        checkNhsGetRequest((HttpGet) httpRequests.get(9));
+        checkNhsGetRequest((HttpGet) httpRequests.get(10));
+
+        // The last is a request to news.gov.scot rss feed
+        checkRssFeedGetRequest((HttpGet) httpRequests.get(11));
     }
 
     private void checkSparQLPostRequest(HttpPost postRequest) throws UnsupportedOperationException, IOException {
@@ -208,19 +385,34 @@ public class LambdaFunctionHandlerTest {
         assertEquals("https://news.gov.scot/feed/rss", getRequest.getURI().toString());
     }
 
+    private void checkNhsGetRequest(HttpGet getRequest) throws UnsupportedOperationException {
+        assertTrue(getRequest.getURI().toString()
+                .startsWith("https://www.opendata.nhs.scot/dataset/b318bddf-a4dc-4262-971f-0ba329e09b87/resource"));
+    }
+
+    private void checkNhsGetRequestModificationDate(HttpGet getRequest, String lastModifiedDate)
+            throws UnsupportedOperationException {
+        if (lastModifiedDate == null) {
+            assertFalse(getRequest.containsHeader("If-Modified-Since"));
+        }
+        else {
+            assertEquals(lastModifiedDate, getRequest.getFirstHeader("If-Modified-Since").getValue());
+        }
+    }
+
     private String readInputStream(InputStream inputStream) {
         return new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8)).lines()
                 .collect(Collectors.joining("\n"));
     }
 
-    private void checkS3Writes(String[] expectedS3Keys, String[] expectedS3Contents)
-            throws UnsupportedOperationException {
+    private void checkS3Writes(String[][] expectedS3Objects) throws UnsupportedOperationException {
 
         List<PutObjectRequest> s3Requests = s3WriteCaptor.getAllValues();
-        assertEquals(expectedS3Keys.length, s3Requests.size());
-        assertArrayEquals(expectedS3Keys, s3Requests.stream().map(PutObjectRequest::getKey).toArray());
-        assertArrayEquals(expectedS3Contents,
-                s3Requests.stream().map(PutObjectRequest::getInputStream).map(this::readInputStream).toArray());
+        assertEquals(expectedS3Objects.length, s3Requests.size());
+        for (int i = 0; i < expectedS3Objects.length; i++) {
+            assertEquals(expectedS3Objects[i][0], s3Requests.get(i).getKey());
+            assertEquals(expectedS3Objects[i][1], readInputStream(s3Requests.get(i).getInputStream()));
+        }
     }
 
 }

--- a/homebrewAWSLambdaServer/src/test/java/org/scottishtecharmy/homebrewdemo/TestContext.java
+++ b/homebrewAWSLambdaServer/src/test/java/org/scottishtecharmy/homebrewdemo/TestContext.java
@@ -126,7 +126,7 @@ public class TestContext implements Context {
     /**
      * A simple {@code LambdaLogger} that prints everything to stderr.
      */
-    private static class TestLogger implements LambdaLogger {
+    static class TestLogger implements LambdaLogger {
 
         @Override
         public void log(String message) {

--- a/homebrewAWSLambdaServer/src/test/java/org/scottishtecharmy/homebrewdemo/TestUtils.java
+++ b/homebrewAWSLambdaServer/src/test/java/org/scottishtecharmy/homebrewdemo/TestUtils.java
@@ -57,7 +57,7 @@ public class TestUtils {
         dynamodbEventMapper.addMixIn(AttributeValue.class, DynamodbEventMixin.AttributeValueMixIn.class);
     }
 
-    private static final DateTimeFormatter dateTimeFormatter =
+    static final DateTimeFormatter dateTimeFormatter =
             ISODateTimeFormat.dateTime()
                         .withZone(new FixedDateTimeZone("GMT", "GMT", 0, 0));
 
@@ -105,7 +105,7 @@ public class TestUtils {
         }
     }
 
-    private static class DateTimeSerializer extends JsonSerializer<DateTime> {
+    static class DateTimeSerializer extends JsonSerializer<DateTime> {
 
         @Override
         public void serialize(
@@ -117,7 +117,7 @@ public class TestUtils {
         }
     }
 
-    private static class DateTimeDeserializer
+    static class DateTimeDeserializer
             extends JsonDeserializer<DateTime> {
 
         @Override
@@ -129,7 +129,7 @@ public class TestUtils {
         }
     }
 
-    private static class UpperCaseRecordsPropertyNamingStrategy
+    static class UpperCaseRecordsPropertyNamingStrategy
             extends PropertyNamingStrategy.PropertyNamingStrategyBase {
 
         private static final long serialVersionUID = 1L;


### PR DESCRIPTION
Polls /www.opendata.nhs.scot for two datasets (by council area and by health board). Makes use of the "If-Modified-Since" HTTP header to only retrieve and store updated data.

Tested on AWS. First run:

Object retrieved from in S3 at data/datesmodified.csv  
Call request
Response received
datesModified not updated - skipping stats queries
**Object not found in S3 at data/nhsDailyCouncilAreaLastModified.txt
Call request
Response received
Response stored in S3 at data/dailyCouncilAreas.csv
Object stored in S3 at data/nhsDailyCouncilAreaLastModified.txt
Last updated stored in S3 at data/nhsDailyCouncilAreaLastModified.txt
Object not found in S3 at data/nhsDailyHealthBoardLastModified.txt
Call request
Response received
Response stored in S3 at data/dailyHealthBoards.csv
Object stored in S3 at data/nhsDailyHealthBoardLastModified.txt
Last updated stored in S3 at data/nhsDailyHealthBoardLastModified.txt**
Call request
Response received
Response stored in S3 at data/newsScotGovRss.xml

Second run:

Object retrieved from in S3 at data/datesmodified.csv
Call request
Response received
datesModified not updated - skipping stats queries
**Object retrieved from in S3 at data/nhsDailyCouncilAreaLastModified.txt
Call request
NHS data not updated - skipping
Object retrieved from in S3 at data/nhsDailyHealthBoardLastModified.txt
Call request
NHS data not updated - skipping**
Call request
Response received
Response stored in S3 at data/newsScotGovRss.xml